### PR TITLE
Add dedicated container for supplier bar scorecard

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,11 +304,15 @@
                 <div class="chart-placeholder">Histogram with Percentile Markers</div>
             </div>
 
-            <div class="chart-container">
-                <h3 class="chart-title">Supplier Scorecard</h3>
-                <div class="chart-placeholder">Multi-dimensional Scorecard Grid (OTD, Quality, SLA)</div>
-            </div>
-        </div>
+              <div class="chart-container">
+                  <h3 class="chart-title">Supplier Scorecard</h3>
+                  <div class="chart-placeholder">Multi-dimensional Scorecard Grid (OTD, Quality, SLA)</div>
+              </div>
+              <div class="chart-container">
+                  <h3 class="chart-title">Supplier Scorecard (Top performers)</h3>
+                  <div class="chart-placeholder">Horizontal Bar Scorecard</div>
+              </div>
+          </div>
 
         <!-- Regulatory & Compliance -->
         <div id="regulatory" class="tab-content">

--- a/script.js
+++ b/script.js
@@ -733,9 +733,9 @@ function renderSupplyCharts(k) {
   }
 
   // Supplier Scorecard (grouped horizontal bars)
-  const cont8 = document.querySelector('#supply .chart-container:nth-of-type(7) .chart-placeholder');
-  if (cont7) {
-    const canvas = makeCanvas(cont7, 'chart_supplier_scorecard');
+  const cont8 = document.querySelector('#supply .chart-container:nth-of-type(8) .chart-placeholder');
+  if (cont8) {
+    const canvas = makeCanvas(cont8, 'chart_supplier_scorecard');
     if (canvas && k.filtered.sp.length > 0) {
       // Aggregate by supplier (average last N months in current filter)
       const bySup = groupBy(k.filtered.sp, 'supplier_id');
@@ -779,8 +779,8 @@ function renderSupplyCharts(k) {
         }
       };
       renderChart('chart_supplier_scorecard', cfg);
-    } else if (cont7) {
-      cont7.innerHTML = '<div style="padding:2rem;text-align:center;color:#64748b;">No supplier data available</div>';
+    } else {
+      cont8.innerHTML = '<div style="padding:2rem;text-align:center;color:#64748b;">No supplier data available</div>';
     }
   }
 


### PR DESCRIPTION
## Summary
- Add eighth chart container in Supply Chain tab for top-performer supplier scorecard bar chart
- Update rendering logic to target new container and avoid conflict with radar chart

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0560f2d8883279610ec04c1edcff8