### PR TITLE
cache filters in refreshAll

### DIFF
--- a/script.js
+++ b/script.js
@@ -1036,12 +1036,13 @@ async function refreshAll() {
   try {
     await ensureChartJs();
     const ds = await api.datasets();
-    const k = computeKPIs(ds, getFilters());
+    const f = getFilters();
+    const k = computeKPIs(ds, f);
 
     updateKPITexts(k);
     
     // Render all charts (remove tab-specific rendering for simplicity)
-    renderExecutiveCharts(k, getFilters());
+    renderExecutiveCharts(k, f);
     renderQualityCharts(k);
     renderSupplyCharts(k);
     renderRegCharts(k);


### PR DESCRIPTION
## Summary
- Cache dashboard filters in refreshAll to avoid repeated `getFilters()` calls
- Pass cached filters to KPI computation and chart rendering

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b054246978832781b470abfea7bf94